### PR TITLE
Use Citrine's last seen commit

### DIFF
--- a/script/tfb-post-process.sh
+++ b/script/tfb-post-process.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# Citrine's latest commit
+if [ "$TFB_USE_LATEST_CITRINE_COMMIT" = true ]; then
+  TFB_COMMIT_HASH=$(curl https://tfb-status.techempower.com/last-seen-commit?environment=Citrine)
+  echo "Using Citrine's commit $TFB_COMMIT_HASH"
+fi
+git -C /mnt/tfb/FrameworkBenchmarks checkout $TFB_COMMIT_HASH
+
 # TFB
 sudo docker build -t techempower/tfb /mnt/tfb/FrameworkBenchmarks
 sudo docker run \

--- a/script/tfb-vm-setup.sh
+++ b/script/tfb-vm-setup.sh
@@ -1,4 +1,4 @@
-!#/bin/bash
+#!/bin/bash
 
 sudo apt-get update
 sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,6 +6,7 @@ variable "TFB_RESULTS_NAME" { default = "results" }
 variable "TFB_RESULTS_ENVIRONMENT" { default = "results_env" }
 variable "TFB_UPLOAD_URI" {}
 variable "TFB_COMMIT_HASH" { default = "" }
+variable "TFB_USE_LATEST_CITRINE_COMMIT" { default = "true" }
 
 variable "VM_PUBLIC_KEY" {}
 variable "VM_PRIVATE_KEY" { default = "to be set" }

--- a/terraform/tfb-app.tf
+++ b/terraform/tfb-app.tf
@@ -104,11 +104,12 @@ resource "azurerm_virtual_machine" "tfb-app" {
       "export TFB_RESULTS_NAME=${var.TFB_RESULTS_NAME}",
       "export TFB_RESULTS_ENVIRONMENT=${var.TFB_RESULTS_ENVIRONMENT}",
       "export TFB_UPLOAD_URI='${var.TFB_UPLOAD_URI}'",
+      "export TFB_COMMIT_HASH=${var.TFB_COMMIT_HASH}",
+      "export TFB_USE_LATEST_CITRINE_COMMIT=${var.TFB_USE_LATEST_CITRINE_COMMIT}",
       "export VM_ADMIN_USERNAME=${var.VM_ADMIN_USERNAME}",
       "sudo mkdir /mnt/tfb",
       "sudo chown ${var.VM_ADMIN_USERNAME} /mnt/tfb",
       "git clone https://github.com/TechEmpower/FrameworkBenchmarks.git /mnt/tfb/FrameworkBenchmarks",
-      "git -C /mnt/tfb/FrameworkBenchmarks checkout ${var.TFB_COMMIT_HASH}",
       "nohup bash /home/${var.VM_ADMIN_USERNAME}/script/tfb-post-process.sh &",
       # Sleep to ensure the previous nohup command is executed
       "sleep 10",


### PR DESCRIPTION
- Set up Azure TFB to use Citrine's last seen commit.
- Minor fixes.