### PR TITLE
Specify a fixed OS version.

### DIFF
--- a/terraform/tfb-app.tf
+++ b/terraform/tfb-app.tf
@@ -51,7 +51,7 @@ resource "azurerm_virtual_machine" "tfb-app" {
     publisher = "Canonical"
     offer     = "UbuntuServer"
     sku       = "16.04-LTS"
-    version   = "latest"
+    version   = "16.04.202004070"
   }
   storage_os_disk {
     name              = "tfb-app-osdisk1"

--- a/terraform/tfb-data.tf
+++ b/terraform/tfb-data.tf
@@ -51,7 +51,7 @@ resource "azurerm_virtual_machine" "tfb-data" {
     publisher = "Canonical"
     offer     = "UbuntuServer"
     sku       = "16.04-LTS"
-    version   = "latest"
+    version   = "16.04.202004070"
   }
   storage_os_disk {
     name              = "tfb-data-osdisk1"

--- a/terraform/tfb-load.tf
+++ b/terraform/tfb-load.tf
@@ -51,7 +51,7 @@ resource "azurerm_virtual_machine" "tfb-load" {
     publisher = "Canonical"
     offer     = "UbuntuServer"
     sku       = "16.04-LTS"
-    version   = "latest"
+    version   = "16.04.202004070"
   }
   storage_os_disk {
     name              = "tfb-load-osdisk1"


### PR DESCRIPTION
Using a specific version (16.04.202004070) of the OS image to minimize performance discrepancy between runs.