### PR TITLE
Match Citrine's Ubuntu release

### DIFF
--- a/terraform/tfb-app.tf
+++ b/terraform/tfb-app.tf
@@ -50,8 +50,8 @@ resource "azurerm_virtual_machine" "tfb-app" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "16.04.202004070"
+    sku       = "18.04-LTS"
+    version   = "18.04.202004080"
   }
   storage_os_disk {
     name              = "tfb-app-osdisk1"

--- a/terraform/tfb-data.tf
+++ b/terraform/tfb-data.tf
@@ -50,8 +50,8 @@ resource "azurerm_virtual_machine" "tfb-data" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "16.04.202004070"
+    sku       = "18.04-LTS"
+    version   = "18.04.202004080"
   }
   storage_os_disk {
     name              = "tfb-data-osdisk1"

--- a/terraform/tfb-load.tf
+++ b/terraform/tfb-load.tf
@@ -50,8 +50,8 @@ resource "azurerm_virtual_machine" "tfb-load" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "16.04.202004070"
+    sku       = "18.04-LTS"
+    version   = "18.04.202004080"
   }
   storage_os_disk {
     name              = "tfb-load-osdisk1"


### PR DESCRIPTION
- Use the same Ubuntu release as what's on Citrine.